### PR TITLE
add versions for crates.io release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ version = "0.1.0"
 
 [workspace.dependencies]
 rtsan-standalone = { path = "." }
-rtsan-standalone-macros = { path = "crates/rtsan-standalone-macros" }
-rtsan-standalone-sys = { path = "crates/rtsan-standalone-sys" }
+rtsan-standalone-macros = { version = "0.1.0", path = "crates/rtsan-standalone-macros" }
+rtsan-standalone-sys = { version = "0.1.0", path = "crates/rtsan-standalone-sys" }
 
 [package]
 authors.workspace = true


### PR DESCRIPTION
We can not publish to crates.io without this change, should have tested it before...