### PR TITLE
Fix early returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "integration-example"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rtsan-standalone",
 ]
@@ -422,7 +422,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rtsan-standalone"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "rtsan-standalone-macros",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "rtsan-standalone-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bumpalo"
@@ -82,18 +82,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -168,9 +168,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "either"
@@ -185,7 +185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -193,6 +193,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "half"
@@ -225,13 +236,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -251,9 +262,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -267,15 +278,15 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -344,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -436,16 +447,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -464,18 +481,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -484,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
@@ -496,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.92"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ae51629bf965c5c098cc9e87908a3df5301051a9e087d6f9bef5c9771ed126"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -507,15 +524,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -545,21 +563,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -571,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -581,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -594,15 +619,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -614,16 +642,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/realtime-sanitizer/rtsan-standalone-rs"
 rust-version = "1.64.0"
-version = "0.1.0"
+version = "0.1.1"
 
 [workspace.dependencies]
 rtsan-standalone = { path = "." }
-rtsan-standalone-macros = { version = "0.1.0", path = "crates/rtsan-standalone-macros" }
+rtsan-standalone-macros = { version = "0.1.1", path = "crates/rtsan-standalone-macros" }
 rtsan-standalone-sys = { version = "0.1.0", path = "crates/rtsan-standalone-sys" }
 
 [package]

--- a/crates/rtsan-standalone-macros/src/lib.rs
+++ b/crates/rtsan-standalone-macros/src/lib.rs
@@ -35,7 +35,7 @@ pub fn nonblocking(_attr: TokenStream, item: TokenStream) -> TokenStream {
             #(#attrs)*
             #vis #sig {
                 rtsan_standalone::realtime_enter();
-                let __result = #block;
+                let __result = (|| { #block })();
                 rtsan_standalone::realtime_exit();
                 __result
             }
@@ -120,7 +120,7 @@ pub fn no_sanitize_realtime(_attr: TokenStream, item: TokenStream) -> TokenStrea
             #(#attrs)*
             #vis #sig {
                 rtsan_standalone::disable();
-                let __result = #block;
+                let __result = (|| { #block })();
                 rtsan_standalone::enable();
                 __result
             }

--- a/crates/rtsan-standalone-macros/src/lib.rs
+++ b/crates/rtsan-standalone-macros/src/lib.rs
@@ -34,10 +34,8 @@ pub fn nonblocking(_attr: TokenStream, item: TokenStream) -> TokenStream {
         let output = quote! {
             #(#attrs)*
             #vis #sig {
-                rtsan_standalone::realtime_enter();
-                let __result = (|| { #block })();
-                rtsan_standalone::realtime_exit();
-                __result
+                let __guard = rtsan_standalone::ScopedSanitizeRealtime::default();
+                #block
             }
         };
         TokenStream::from(output)
@@ -119,10 +117,8 @@ pub fn no_sanitize_realtime(_attr: TokenStream, item: TokenStream) -> TokenStrea
         let output = quote! {
             #(#attrs)*
             #vis #sig {
-                rtsan_standalone::disable();
-                let __result = (|| { #block })();
-                rtsan_standalone::enable();
-                __result
+                let __guard = rtsan_standalone::ScopedDisabler::default();
+                #block
             }
         };
         TokenStream::from(output)

--- a/crates/rtsan-standalone-sys/Cargo.toml
+++ b/crates/rtsan-standalone-sys/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 name = "rtsan-standalone-sys"
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [build-dependencies]
 num_cpus = "1.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ pub fn notify_blocking_call(function_name: &'static str) {
 #[macro_export]
 macro_rules! scoped_disabler {
     ($($body:tt)*) => {{
-        let __guard = ScopedDisabler::default();
+        let __guard = rtsan_standalone::ScopedDisabler::default();
         $($body)*
     }};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,14 +362,11 @@ macro_rules! scoped_disabler {
 /// use rtsan_standalone::*;
 ///
 /// fn process() {
-///     let _guard = ScopedSanitizeRealtime::default();
-///     let _ = vec![0.0; 256]; // oops!
-/// }
-///
-/// // Macro usage preferred
-/// #[nonblocking]
-/// fn process_preferred() {
-///     let _ = vec![0.0; 256]; // oops!
+///     {
+///         let _guard = ScopedSanitizeRealtime::default();
+///         let _ = vec![0.0; 256]; // not ok
+///     }
+///     let _ = vec![0.0; 256]; // ok
 /// }
 pub struct ScopedSanitizeRealtime;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,11 +346,83 @@ pub fn notify_blocking_call(function_name: &'static str) {
 #[macro_export]
 macro_rules! scoped_disabler {
     ($($body:tt)*) => {{
-        rtsan_standalone::disable();
-        let __result = (|| {
-            $($body)*
-        })();
-        rtsan_standalone::enable();
-        __result
+        let __guard = ScopedDisabler::default();
+        $($body)*
     }};
+}
+
+/// Enter real-time context for the lifetime of the object.
+/// When in a real-time context, RTSan interceptors will error if realtime
+/// violations are detected.
+/// Corresponds to a [`nonblocking`] macro.
+///
+/// # Example
+///
+/// ```
+/// use rtsan_standalone::*;
+///
+/// fn process() {
+///     let _guard = ScopedSanitizeRealtime::default();
+///     let _ = vec![0.0; 256]; // oops!
+/// }
+///
+/// // Macro usage preferred
+/// #[nonblocking]
+/// fn process_preferred() {
+///     let _ = vec![0.0; 256]; // oops!
+/// }
+pub struct ScopedSanitizeRealtime;
+
+impl Default for ScopedSanitizeRealtime {
+    fn default() -> Self {
+        realtime_enter();
+        Self
+    }
+}
+
+impl Drop for ScopedSanitizeRealtime {
+    fn drop(&mut self) {
+        realtime_exit();
+    }
+}
+
+/// Disable all RTSan error reporting in an otherwise real-time context,
+/// for the lifetime of the object.
+/// Corresponds to a [`scoped_disabler`] or [`no_sanitize_realtime`] macro.
+///
+/// # Example
+///
+/// ```
+/// use rtsan_standalone::*;
+///
+/// #[nonblocking]
+/// fn process() {
+///     {
+///         let _guard = ScopedDisabler::default();
+///         let mut data = vec![0.0; 16]; // ok
+///     }
+///     let mut data = vec![0.0; 16]; // not ok
+/// }
+///
+/// // Macro usage preferred
+/// #[nonblocking]
+/// fn process_preferred() {
+///     scoped_disabler!({
+///         let mut data = vec![0.0; 16]; // ok
+///     });
+///     let mut data = vec![0.0; 16]; // not ok
+/// }
+pub struct ScopedDisabler;
+
+impl Default for ScopedDisabler {
+    fn default() -> Self {
+        disable();
+        Self
+    }
+}
+
+impl Drop for ScopedDisabler {
+    fn drop(&mut self) {
+        enable();
+    }
 }

--- a/tests/rtsan-macros.rs
+++ b/tests/rtsan-macros.rs
@@ -1,4 +1,6 @@
-use rtsan_standalone::*;
+use rtsan_standalone::{
+    blocking, ensure_initialized, no_sanitize_realtime, nonblocking, scoped_disabler,
+};
 
 #[nonblocking]
 fn create_array_function() {

--- a/tests/rtsan-macros.rs
+++ b/tests/rtsan-macros.rs
@@ -67,3 +67,26 @@ fn test_blocking() {
 
     call_blocking_function();
 }
+
+#[nonblocking]
+fn early_return(r: &[f32]) -> Option<&[f32]> {
+    let r = r;
+    for r in r.iter() {
+        if *r == 1.0 {
+            return None;
+        }
+    }
+    Some(r)
+}
+
+#[test]
+fn test_early_return() {
+    ensure_initialized();
+    let data = vec![1.0; 16];
+    let a = early_return(&data);
+    assert_eq!(a, None);
+
+    let data = vec![0.0; 16];
+    let a = early_return(&data);
+    assert_eq!(a, Some(data.as_slice()));
+}


### PR DESCRIPTION
As stated in issue #4 with the current approach the return could skip the `realtime_disable` call in some situations. That's why there is a switch to the guards approach, that is also used in the original header file.

Two guard structs are introduced:

- `ScopedSanitizeRealtime`
- `ScopedDisabler`

The macros now initiate these guards instead of calling the function directly after the codeblock.

Version number is bumped to `0.1.1` as this is no breaking change, all prior code still works.
Version number of the `rtsan-standalone-sys` crate is uncoupled now from the other crates, as it does not need to be re-built.

An additional test is introduced for early returns and the tests do not import all things anymore.