### PR TITLE
Update to released tag of LLVM 20.1.0

### DIFF
--- a/crates/rtsan-standalone-sys/build.rs
+++ b/crates/rtsan-standalone-sys/build.rs
@@ -59,6 +59,8 @@ fn main() {
             "-n",
             "--depth=1",
             "--filter=tree:0",
+            "--branch",
+            "llvmorg-20.1.0",
             "https://github.com/llvm/llvm-project.git",
             llvm_project_dir.to_str().unwrap(),
         ],


### PR DESCRIPTION
LLVM 20.1.0 is the first official version with rtsan support. Pin to it so we are all on the same page.

Official tag:
https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0

Relevant release notes:
https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html#sanitizers