### PR TITLE
Switch to CStr for FFI

### DIFF
--- a/crates/rtsan-standalone-macros/src/lib.rs
+++ b/crates/rtsan-standalone-macros/src/lib.rs
@@ -57,6 +57,8 @@ pub fn blocking(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let block = input.block; // Function body
     let mut function_name = sig.ident.to_string();
     function_name.push('\0');
+    let function_name_bytes = function_name.into_bytes();
+    let function_name = core::ffi::CStr::from_bytes_with_nul(&function_name_bytes).unwrap();
 
     // Generate the transformed function
     let output = quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub fn ensure_initialized() {
 /// use rtsan_standalone::*;
 ///
 /// fn my_blocking_function() {
-///     notify_blocking_call("my_blocking_function\0");
+///     notify_blocking_call(c"my_blocking_function");
 /// }
 ///
 /// // Preferred macro usage
@@ -175,12 +175,9 @@ pub fn ensure_initialized() {
 /// fn my_blocking_function_preferred() {}
 /// ```
 #[allow(unused_variables)]
-pub fn notify_blocking_call(function_name: &'static str) {
+pub fn notify_blocking_call(function_name: &'static core::ffi::CStr) {
     #[cfg(rtsan_enabled)]
     {
-        if !function_name.ends_with('\0') {
-            panic!("`notify_blocking_call` requires a null-terminated function name (e.g., \"my_function_name\\0\").");
-        }
         unsafe {
             rtsan_standalone_sys::__rtsan_notify_blocking_call(
                 function_name.as_ptr() as *const core::ffi::c_char

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,10 +157,6 @@ pub fn ensure_initialized() {
 /// Including this in the first line of a function definition is
 /// analogous to marking a function  with the [`blocking`] macro.
 ///
-/// # Panics
-///
-/// Panics if the provided string is not null-terminated.
-///
 /// # Example
 ///
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,9 +175,7 @@ pub fn notify_blocking_call(function_name: &'static core::ffi::CStr) {
     #[cfg(rtsan_enabled)]
     {
         unsafe {
-            rtsan_standalone_sys::__rtsan_notify_blocking_call(
-                function_name.as_ptr() as *const core::ffi::c_char
-            );
+            rtsan_standalone_sys::__rtsan_notify_blocking_call(function_name.as_ptr());
         }
     }
 }


### PR DESCRIPTION
No runtime panic anymore, as the need to have a null terminator is shifted to the user of the API. CStr literals are stable since 1.77 so they are easy to create on the MSRV.

This is a breaking change, but this can be done in the same version increase as the enable switch, so doesn't need to wait.