### PR TITLE
Change Description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rtsan-standalone-sys = { version = "0.2.0", path = "crates/rtsan-standalone-sys"
 [package]
 authors.workspace = true
 categories.workspace = true
-description = "A Rust wrapper for RTSan standalone"
+description = "Standalone RealtimeSanitizer for Rust"
 edition.workspace = true
 keywords.workspace = true
 license.workspace = true


### PR DESCRIPTION
Main reason for another description is, that on crates.io the word RealtimeSanitizer is not showing up at a single point. When I am scrolling through crates the word `RTSAN` might not mean something for me, while the description will make it clearer.
Took the same as the repo description.